### PR TITLE
Respect no_cache GET-parameter and no-cache HTTP header

### DIFF
--- a/Classes/Hooks/RenderPreProcessorHook.php
+++ b/Classes/Hooks/RenderPreProcessorHook.php
@@ -83,7 +83,8 @@ class tx_Wsless_Hooks_RenderPreProcessorHook {
 			}
 
 			try {
-				if ($contentHashCache == '' || $contentHashCache != $contentHash)
+				if ($contentHashCache == '' || $contentHashCache != $contentHash
+					|| $GLOBALS['TSFE']->no_cache || $GLOBALS['TSFE']->headerNoCache())
 				{
 					$this->compileScss($lessFilename, $cssFilename);
 				}


### PR DESCRIPTION
Ignore local cache and force compilation if URL contains ?no_cache=1 or 'no-cache' HTTP headers are set (e.g. if refreshing page with CTRL+F5).
