### PR TITLE
Support relative paths in less files with output dir different than source file + other small fixes

### DIFF
--- a/Classes/Hooks/RenderPreProcessorHook.php
+++ b/Classes/Hooks/RenderPreProcessorHook.php
@@ -161,6 +161,8 @@ class RenderPreProcessorHook {
 			return '';
 		}
 
+		$this->initializeLessParser();
+
 		// compare input directory with output and if different
 		// define a prefix for resource pathes in order to make
 		// relative paths used in less files work correctly
@@ -175,10 +177,6 @@ class RenderPreProcessorHook {
 			}
 			$resourcePathPrefix = rtrim($prefix, '/') . '/' . str_replace(PATH_site, '', $infoLessFile['dirname']);
 		}
-
-		$extPath = \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath('ws_less');
-		require_once($extPath.'Resources/Private/less.php/lib/Less/Autoloader.php');
-		\Less_Autoloader::register();
 
 		$parser = new \Less_Parser();
 		$parser->parseFile($lessFilename, $resourcePathPrefix);
@@ -215,6 +213,18 @@ class RenderPreProcessorHook {
 		return $hash;
 	}
 
+	/**
+	 * Initializes the less parser
+	 *
+	 * @return void
+	 */
+	protected function initializeLessParser() {
+		if (!class_exists('Less_Autoloader')) {
+			$extPath = \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath('ws_less');
+			require_once($extPath . 'Resources/Private/less.php/lib/Less/Autoloader.php');
+			\Less_Autoloader::register();
+		}
+	}
 
 }
 ?>

--- a/Classes/Hooks/RenderPreProcessorHook.php
+++ b/Classes/Hooks/RenderPreProcessorHook.php
@@ -82,11 +82,12 @@ class RenderPreProcessorHook {
 			$outputdir = $this->defaultoutputdir;
 
 			// search settings for less file
-			foreach ($GLOBALS['TSFE']->pSetup['includeCSS.'] as $key => $subconf) {
-
-				if (is_string($GLOBALS['TSFE']->pSetup['includeCSS.'][$key]) && $GLOBALS['TSFE']->tmpl->getFileName($GLOBALS['TSFE']->pSetup['includeCSS.'][$key]) == $file) {
-					if (isset($GLOBALS['TSFE']->pSetup['includeCSS.'][$key.'.']['outputdir']))
-						$outputdir = trim($GLOBALS['TSFE']->pSetup['includeCSS.'][$key.'.']['outputdir']);
+			if (is_array($GLOBALS['TSFE']->pSetup['includeCSS.'])) {
+				foreach ($GLOBALS['TSFE']->pSetup['includeCSS.'] as $key => $subconf) {
+					if (is_string($GLOBALS['TSFE']->pSetup['includeCSS.'][$key]) && $GLOBALS['TSFE']->tmpl->getFileName($GLOBALS['TSFE']->pSetup['includeCSS.'][$key]) == $file) {
+						if (isset($GLOBALS['TSFE']->pSetup['includeCSS.'][$key . '.']['outputdir']))
+							$outputdir = trim($GLOBALS['TSFE']->pSetup['includeCSS.'][$key.'.']['outputdir']);
+					}
 				}
 			}
 


### PR DESCRIPTION
This PR addresses a couple bugs I encountered when working with ws_less. The most noticible one is that relative include paths now work in less files when the output dir is different from the source less file (8c30b59). The other commits are mostly cleanups and small fixes to prevent exceptions/errors in some rare situations.