### PR TITLE
fix cache always rewritten even without changes

### DIFF
--- a/Classes/Hooks/RenderPreProcessorHook.php
+++ b/Classes/Hooks/RenderPreProcessorHook.php
@@ -125,8 +125,9 @@ class RenderPreProcessorHook {
 				$contentHashCache = $cache->get($cacheKey);
 			}
 
+			$requiresCompilation = $contentHashCache == '' || $contentHashCache != $contentHash;
 			try {
-				if ($contentHashCache == '' || $contentHashCache != $contentHash) {
+				if ($requiresCompilation) {
 					$this->compileScss($lessFilename,$cssFilename,$strVars);
 				}
 			} catch (Exception $ex) {
@@ -134,10 +135,11 @@ class RenderPreProcessorHook {
 				echo $ex->getMessage();
 
                 GeneralUtility::sysLog($ex->getMessage(),GeneralUtility::SYSLOG_SEVERITY_ERROR);
-
 			}
 
-			$cache->set($cacheKey,$contentHash,array());
+			if ($requiresCompilation) {
+				$cache->set($cacheKey,$contentHash,array());
+			}
 
 			$cssFiles[$cssRelativeFilename] = $params['cssFiles'][$file];
 			$cssFiles[$cssRelativeFilename]['file'] = $cssRelativeFilename;


### PR DESCRIPTION
Currently the cache will always be set on every request. The problem is that the cache framework isn't [atomic](http://stackoverflow.com/questions/15054086/what-does-atomic-mean-in-programming) and delivers empty results if the cache is written in the exact moment it is read.