### PR TITLE
CacheKey must contains strVars

### DIFF
--- a/Classes/Hooks/RenderPreProcessorHook.php
+++ b/Classes/Hooks/RenderPreProcessorHook.php
@@ -120,7 +120,7 @@ class RenderPreProcessorHook {
 
 			$cache = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('TYPO3\\CMS\\Core\\Cache\\CacheManager')->getCache('ws_less');
 
-			$cacheKey = hash('sha1',$cssRelativeFilename);
+			$cacheKey = hash('sha1',$cssRelativeFilename . $strVars);
 			$contentHash = $this->calculateContentHash($lessFilename,$strVars);
 			$contentHashCache = '';
 			if ($cache->has($cacheKey)) {


### PR DESCRIPTION
Since the strVars will are used for file hash calculation, it must also be used for cacheKey calculations. If not, the same file will be generated multiple times when switching between pages that use different variable values.