### PR TITLE
TYPO3 v13 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
 		}
 	],
 	"require": {
-		"typo3/cms-core": "^12.4",
+		"typo3/cms-core": "^12.4 || ^13.4",
 		"wikimedia/less.php": "^3.1.0"
 	},
 	"autoload": {


### PR DESCRIPTION
To make this Extension compatibile with TYPO3 v13 it is enough to simply allow ^13.4 in composer.json.

Sure, the usages of $GLOBALS['TSFE'] inside the codebase are now deprecated but that won't be an issue until v14 :)